### PR TITLE
Fix DOMContentLoaded syntax in frontend

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -392,6 +392,7 @@
            l.includes('oscario')?'oscario':
            l.includes('sand')?'sand':'';
   }
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- close the DOMContentLoaded listener in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e78a263608321af40b3070a980189