### PR TITLE
Fix DOMContentLoaded handler scope

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -378,6 +378,19 @@
       .catch(e=>alert('Error marking payout: '+e));
   }
 
+  // Expose functions globally for inline handlers
+  Object.assign(window, {
+    showTab,
+    startScanner,
+    manualAdd,
+    loadOrders,
+    updateOrderStatus,
+    updateOrderNotes,
+    updateCashAmount,
+    loadPayouts,
+    markPayoutPaid
+  });
+
   /* ─────────────────────────────────────────────────────────────
      9.  Helper – tag mapping  (unchanged)
      ────────────────────────────────────────────────────────────*/
@@ -392,6 +405,7 @@
            l.includes('oscario')?'oscario':
            l.includes('sand')?'sand':'';
   }
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose UI functions globally so inline onclick handlers work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e78a263608321af40b3070a980189