### PR TITLE
🔧 Improve payouts loading

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -470,13 +470,17 @@ def get_payouts(driver: str = Query(...)):
         return payouts_cache[driver]
 
     ws_orders, ws_payouts = _tabs_for(driver)
+    # Fetch orders sheet once and build a lookup dictionary
+    orders_data = ws_orders.get_all_values()
+    order_lookup = {row[1]: row for row in orders_data[1:]}
+
     rows = ws_payouts.get_all_values()[1:]
     payouts = []
     for r in reversed(rows):
         orders_list = [o.strip() for o in (r[2] or "").split(',') if o.strip()]
         order_details = []
         for name in orders_list:
-            row = get_order_row(ws_orders, name)
+            row = order_lookup.get(name)
             if row:
                 order_details.append({
                     "name": name,

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -189,8 +189,8 @@
     document.querySelector(`[onclick="showTab('${t}')"]`).classList.add('active');
     document.querySelectorAll('.tab-content').forEach(e=>e.classList.remove('active'));
     document.getElementById(`${t}-tab`).classList.add('active');
-    if(t==='orders')  loadOrders();
-    if(t==='payouts') loadPayouts();
+    if(t==='orders' && !orders.length)  loadOrders();
+    if(t==='payouts' && !payouts.length) loadPayouts();
   }
 
   /* ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- speed up `/payouts` endpoint by loading orders sheet once and using a lookup
- don't refetch orders or payouts when switching tabs if data is already loaded

## Testing
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68643680e6fc83219694951eaf6dc40c