### PR TITLE
Improve header layout

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -9,9 +9,12 @@
   <style>
     *{margin:0;padding:0;box-sizing:border-box}
     body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;background:#f5f7fa;color:#333;line-height:1.6}
-    .header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
-    .logo-icon{width:64px;height:64px;margin:0 auto 0.5rem auto;display:block}
-    .driver-name{font-size:1.8rem;margin-bottom:0.5rem;font-weight:1000}
+    .top-header{background:white;text-align:center;padding:0.5rem 1rem;box-shadow:0 2px 4px rgba(0,0,0,0.05)}
+    .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
+    .logo-icon{width:64px;height:64px;margin:0 auto;display:block}
+    .driver-info{margin-top:0.3rem;font-weight:600;display:flex;justify-content:center;gap:0.5rem;align-items:center}
+    .driver-name{font-size:1.2rem;text-transform:uppercase}
+    .current-time{font-size:1rem}
     .nav-tabs{display:flex;background:white;border-bottom:2px solid #e1e8ed;position:sticky;top:0;z-index:100}
     .nav-tab{flex:1;padding:1rem;text-align:center;cursor:pointer;border:none;background:white;font-size:1rem;font-weight:600;color:#666;transition:all 0.3s ease}
     .nav-tab.active{color:#004aad;border-bottom:3px solid #004aad;background:#f8faff}
@@ -96,10 +99,15 @@
   </style>
 </head>
 <body>
-  <div class="header">
+  <div class="top-header">
     <img src="favicon.png" alt="Logo" class="logo-icon">
-    <div id="driverName" class="driver-name"></div>
+  </div>
+  <div class="main-header">
     <h1>📦 Delivery Management</h1>
+    <div class="driver-info">
+      <span id="driverName" class="driver-name"></span>
+      <span id="currentTime" class="current-time"></span>
+    </div>
   </div>
   
   <div class="nav-tabs">
@@ -166,11 +174,19 @@
         return; // stop further execution if no driver
       }
 
-      // Display driver name in header
+      // Display driver name and current time in header
       const driverNameEl = document.getElementById('driverName');
-      if (driverNameEl) {
-        driverNameEl.textContent = `${driver_id}`;
+      const currentTimeEl = document.getElementById('currentTime');
+      function updateTime(){
+        const now = new Date();
+        const timeStr = now.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+        if(currentTimeEl) currentTimeEl.textContent = timeStr;
       }
+      if (driverNameEl) {
+        driverNameEl.textContent = driver_id.toUpperCase();
+      }
+      updateTime();
+      setInterval(updateTime, 60000);
 
     
   /* ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- split the header into a white top section and a main section
- show driver name in uppercase with current time

## Testing
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68643b3eb3fc8321b83caa18711ddafd