### PR TITLE
Adjust logo size

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -11,7 +11,7 @@
     body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;background:#f5f7fa;color:#333;line-height:1.6}
     .top-header{background:white;text-align:center;padding:0.5rem 1rem;box-shadow:0 2px 4px rgba(0,0,0,0.05)}
     .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
-    .logo-icon{width:80px;height:64px;margin:0 auto;display:block}
+    .logo-icon{width:120px;height:auto;margin:0 auto;display:block}
     .driver-info{margin-top:0.3rem;font-weight:600;display:flex;justify-content:center;gap:0.5rem;align-items:center}
     .driver-name{font-size:1.2rem;text-transform:uppercase}
     .current-time{font-size:1rem}


### PR DESCRIPTION
## Summary
- keep delivery management logo crisp

## Testing
- `bash -lc 'true'`

------
https://chatgpt.com/codex/tasks/task_e_6864413d228483218c2bc321e4af8f39