### PR TITLE
Add admin dashboard

### DIFF
--- a/backend/app/static/admin.html
+++ b/backend/app/static/admin.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin Dashboard</title>
+  <style>
+    body{font-family:sans-serif;margin:0;padding:1rem;background:#f5f7fa;}
+    h1{text-align:center;margin-bottom:1rem;color:#004aad;}
+    table{width:100%;border-collapse:collapse;background:white;box-shadow:0 2px 10px rgba(0,0,0,0.1);}
+    th,td{padding:0.6rem 0.8rem;border-bottom:1px solid #ddd;text-align:center;}
+    th{background:#004aad;color:white;}
+  </style>
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <table id="statsTable">
+    <thead>
+      <tr>
+        <th>Driver</th>
+        <th>Total Orders</th>
+        <th>Delivered</th>
+        <th>Returned</th>
+        <th>Delivery Rate</th>
+        <th>Total Collect</th>
+        <th>Total Fees</th>
+      </tr>
+    </thead>
+    <tbody id="statsBody"></tbody>
+  </table>
+
+  <script>
+    fetch('/admin/stats')
+      .then(r=>r.json())
+      .then(data=>{
+        const body=document.getElementById('statsBody');
+        Object.entries(data).forEach(([driver,s])=>{
+          const tr=document.createElement('tr');
+          tr.innerHTML=`<td>${driver}</td>
+                         <td>${s.totalOrders}</td>
+                         <td>${s.delivered}</td>
+                         <td>${s.returned}</td>
+                         <td>${s.deliveryRate.toFixed(0)}%</td>
+                         <td>${s.totalCollect.toFixed(2)}</td>
+                         <td>${s.totalFees.toFixed(2)}</td>`;
+          body.appendChild(tr);
+        });
+      });
+  </script>
+</body>
+</html>

--- a/backend/app/static/admin_login.html
+++ b/backend/app/static/admin_login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin Login</title>
+  <style>
+    body {font-family:sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;background:#f0f0f0;margin:0;}
+    .login-box {background:white;padding:2rem;border-radius:12px;box-shadow:0 2px 20px rgba(0,0,0,0.1);text-align:center;}
+    h2 {margin-bottom:1rem;color:#004aad;}
+    input[type="password"] {padding:0.8rem;width:100%;margin-bottom:1rem;font-size:1rem;border:2px solid #ccc;border-radius:8px;}
+    button {padding:0.8rem 1.5rem;background:#004aad;color:white;border:none;border-radius:8px;font-size:1rem;cursor:pointer;}
+    button:hover {background:#0066cc;}
+  </style>
+</head>
+<body>
+  <div class="login-box">
+    <h2>🔒 Admin Login</h2>
+    <input id="adminPassword" type="password" placeholder="Enter admin password" />
+    <button onclick="login()">Login</button>
+  </div>
+
+  <script>
+    function login() {
+      const pw = document.getElementById('adminPassword').value.trim();
+      fetch('/admin/login', {method:'POST', body:new URLSearchParams({password: pw})})
+        .then(r => r.ok ? location.href='/static/admin.html' : alert('Invalid password'));
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple admin authentication endpoint
- provide driver list and aggregated stats API
- serve admin login and dashboard pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864420fa1248321b0e77dfc263d8f97