### PR TITLE
Define env constants for archive

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,10 @@ SHOPIFY_STORES = [
     },
 ]
 
+# Sheet configuration (default names can be overridden via env vars)
+SHEET_NAME = os.getenv("SHEET_NAME")
+DELIVERY_GUY_NAME = os.getenv("DELIVERY_GUY_NAME", "delivery")
+
 DELIVERY_STATUSES   = [
     "Dispatched", "Livré", "En cours",
     "Pas de réponse 1", "Pas de réponse 2", "Pas de réponse 3",


### PR DESCRIPTION
## Summary
- add `SHEET_NAME` and `DELIVERY_GUY_NAME` variables in the configuration section
- use these constants inside `/archive-yesterday`

## Testing
- `python3 -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686450ca61c4832181984b148a9b0bb9