### PR TITLE
Display canceled amounts in admin stats

### DIFF
--- a/backend/app/static/admin.html
+++ b/backend/app/static/admin.html
@@ -44,6 +44,7 @@
         <th>Total Orders</th>
         <th>Delivered</th>
         <th>Returned</th>
+        <th>Canceled DH</th>
         <th>Delivery Rate</th>
         <th>Total Collect</th>
         <th>Total Fees</th>
@@ -98,6 +99,7 @@
                       <td>${s.totalOrders||0}</td>
                       <td>${s.delivered||0}</td>
                       <td>${s.returned||0}</td>
+                      <td>${(s.canceledAmount||0).toFixed(2)}</td>
                       <td>${(s.deliveryRate||0).toFixed(0)}%</td>
                       <td>${(s.totalCollect||0).toFixed(2)}</td>
                       <td>${(s.totalFees||0).toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- update admin HTML to show canceled cash amounts per driver

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867de832c888321994fc42ca5732574