### PR TITLE
Add caching for sheet data

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -161,8 +161,9 @@ DRIVERS = {
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin123")
 
 # In-memory caches for orders and payouts
-orders_cache = TTLCache(maxsize=8, ttl=30)
-payouts_cache = TTLCache(maxsize=8, ttl=30)
+orders_cache = TTLCache(maxsize=8, ttl=300)    # five minutes
+payouts_cache = TTLCache(maxsize=8, ttl=300)
+orders_data_cache = TTLCache(maxsize=8, ttl=120)
 
 @app.get("/", response_class=HTMLResponse)
 async def show_login():
@@ -429,6 +430,7 @@ def scan(
     # invalidate caches for this driver
     orders_cache.pop(driver, None)
     payouts_cache.pop(driver, None)
+    orders_data_cache.pop(driver, None)
 
     return ScanResult(
         result=result_msg,
@@ -443,8 +445,12 @@ def list_active_orders(driver: str = Query(...)):
     if driver in orders_cache:
         return orders_cache[driver]
 
-    ws_orders, _ = _tabs_for(driver)
-    data = ws_orders.get_all_values()[1:]  # skip header
+    data = orders_data_cache.get(driver)
+    if data is None:
+        ws_orders, _ = _tabs_for(driver)
+        data = ws_orders.get_all_values()
+        orders_data_cache[driver] = data
+    data = data[1:]  # skip header
     active = []
     for r in data:
         if not r or r[9] in COMPLETED_STATUSES:
@@ -537,6 +543,7 @@ def update_order_status(
     # invalidate caches for this driver
     orders_cache.pop(driver, None)
     payouts_cache.pop(driver, None)
+    orders_data_cache.pop(driver, None)
 
     return {"success": True}
 
@@ -548,7 +555,10 @@ def get_payouts(driver: str = Query(...)):
 
     ws_orders, ws_payouts = _tabs_for(driver)
     # Fetch orders sheet once and build a lookup dictionary
-    orders_data = ws_orders.get_all_values()
+    orders_data = orders_data_cache.get(driver)
+    if orders_data is None:
+        orders_data = ws_orders.get_all_values()
+        orders_data_cache[driver] = orders_data
     order_lookup = {row[1]: row for row in orders_data[1:]}
 
     rows = ws_payouts.get_all_values()[1:]
@@ -596,6 +606,7 @@ def mark_payout_paid(payout_id: str, driver: str = Query(...)):
     # invalidate caches for this driver
     payouts_cache.pop(driver, None)
     orders_cache.pop(driver, None)
+    orders_data_cache.pop(driver, None)
 
     return {"success": True}
 
@@ -607,8 +618,12 @@ def _compute_stats(
     start: str | None = None,
     end: str | None = None,
 ) -> dict:
-    ws_orders, _ = _tabs_for(driver)
-    rows = ws_orders.get_all_values()[1:]
+    data = orders_data_cache.get(driver)
+    if data is None:
+        ws_orders, _ = _tabs_for(driver)
+        data = ws_orders.get_all_values()
+        orders_data_cache[driver] = data
+    rows = data[1:]
 
     if start:
         try:
@@ -713,8 +728,12 @@ def admin_trends(
 
     counts: dict[dt.date, int] = {}
     for driver in DRIVERS.keys():
-        ws_orders, _ = _tabs_for(driver)
-        rows = ws_orders.get_all_values()[1:]
+        data = orders_data_cache.get(driver)
+        if data is None:
+            ws_orders, _ = _tabs_for(driver)
+            data = ws_orders.get_all_values()
+            orders_data_cache[driver] = data
+        rows = data[1:]
         for r in rows:
             scan_day = get_cell(r, 12)
             status = get_cell(r, 9)


### PR DESCRIPTION
## Summary
- extend caching system with a new `orders_data_cache`
- use cached sheet data in order/payout/stats endpoints
- bump order/payout cache TTL to 5 minutes
- clear cached data whenever sheets are updated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686820b5e5d08321a35e5efc10bee070