### PR TITLE
Improve admin dashboard visuals

### DIFF
--- a/backend/app/static/admin.html
+++ b/backend/app/static/admin.html
@@ -6,15 +6,16 @@
   <title>Admin Dashboard</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <style>
-    body{font-family:sans-serif;background:#f5f7fa;}
+    body{font-family:sans-serif;background:linear-gradient(to bottom,#f5f7fa,#e2e8f0);min-height:100vh;}
     .logo-icon{width:120px;height:auto;margin:0 auto;display:block}
-    .main-header{background:linear-gradient(135deg,#004aad,#0066cc);color:white;padding:1rem;text-align:center;box-shadow:0 2px 10px rgba(0,0,0,0.1)}
-    /* make stats table horizontally scrollable on small screens */
-    #statsTable{min-width:850px}
-    #statsTable th,#statsTable td{padding:0.5rem;white-space:nowrap}
+    .main-header{background:linear-gradient(135deg,#2563eb,#1d4ed8);color:white;padding:1.2rem;text-align:center;box-shadow:0 4px 15px rgba(0,0,0,0.1);border-radius:0 0 12px 12px}
+    #statsWrapper{max-height:400px;overflow:auto}
+    #statsTable{min-width:850px;width:100%}
+    #statsTable th{background:#f0f0f0;font-weight:600}
+    #statsTable th,#statsTable td{padding:0.5rem;white-space:nowrap;border-bottom:1px solid #e5e7eb}
     @media(max-width:640px){#statsTable{font-size:0.75rem}}
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 </head>
 <body>
   <div class="bg-white py-2 shadow">
@@ -64,7 +65,7 @@
     </div>
   </div>
 
-  <div class="overflow-x-auto">
+  <div id="statsWrapper" class="overflow-x-auto rounded shadow bg-white mx-auto my-4">
   <table id="statsTable" class="min-w-max text-sm">
     <thead>
       <tr>
@@ -171,7 +172,7 @@
     }
 
     function renderChart(labels,data){
-      const ctx=document.getElementById('statsChart');
+      const ctx=document.getElementById('statsChart').getContext('2d');
       if(window.statsChart) window.statsChart.destroy();
       window.chartLabels=labels;
       window.chartData=data;
@@ -179,7 +180,7 @@
     }
 
     function renderSummary(sum){
-      const ctx=document.getElementById('summaryChart');
+      const ctx=document.getElementById('summaryChart').getContext('2d');
       if(window.summaryChart) window.summaryChart.destroy();
       const labels=['Delivered','Collected DH','Canceled','Canceled DH'];
       const data=[sum.delivered,sum.collected.toFixed(2),sum.canceled,sum.canceledAmt.toFixed(2)];
@@ -198,7 +199,7 @@
     }
 
     function renderTrendChart(trendStats){
-      const ctx=document.getElementById('trendChart');
+      const ctx=document.getElementById('trendChart').getContext('2d');
       if(window.trendChart) window.trendChart.destroy();
       const labels=trendStats.map(d=>d.date);
       const data=trendStats.map(d=>d.delivered);


### PR DESCRIPTION
## Summary
- update admin dashboard look with gradients and card styles
- upgrade to Chart.js 4 and ensure chart contexts are used
- make stats table scrollable inside a styled wrapper

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `black --check backend/app/main.py` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_e_686980a5d37c8321b24e7c50a438add5