### PR TITLE
Improve realtime data handling

### DIFF
--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -238,6 +238,16 @@
       setInterval(updateTime, 60000);
       loadStatsHeader();
       applyDefaultRange();
+      loadOrders();
+      loadPayouts();
+      setInterval(() => {
+        if(document.getElementById('orders-tab').classList.contains('active')) {
+          loadOrders();
+        }
+        if(document.getElementById('payouts-tab').classList.contains('active')) {
+          loadPayouts();
+        }
+      }, 30000);
 
     
   /* ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- decrease API cache TTL for fresher reads
- add helper to remove orders from a payout when status changes
- update status endpoint to keep payouts consistent
- auto-refresh orders and payouts on the frontend

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e523ef7148321b0e44de659e416b9