### PR TITLE
Add communication log storage

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -129,6 +129,7 @@ class StatusUpdate(BaseModel):
     note: Optional[str] = None
     cash_amount: Optional[float] = None
     scheduled_time: Optional[str] = None
+    comm_log: Optional[str] = None
 
 
 class ManualAdd(BaseModel):
@@ -298,7 +299,7 @@ ORDER_HEADER = [
     "Timestamp", "Order Name", "Customer Name", "Customer Phone",
     "Address", "Tags", "Fulfillment", "Order Status",
     "Store", "Delivery Status", "Notes", "Scheduled Time", "Scan Date",
-    "Cash Amount", "Driver Fee", "Payout ID", "Status Log"
+    "Cash Amount", "Driver Fee", "Payout ID", "Status Log", "Comm Log"
 ]
 
 PAYOUT_HEADER = [
@@ -539,6 +540,7 @@ def list_active_orders(driver: str = Query(...)):
             "driverFee":    safe_float(get_cell(r, 14)),
             "payoutId":     r[15],
             "statusLog":    get_cell(r, 16),
+            "commLog":      get_cell(r, 17),
         })
     def sort_key(o):
         if o["scheduledTime"]:
@@ -581,7 +583,7 @@ def update_order_status(
     row = cells[0].row
     row_vals = ws_orders.row_values(row)
 
-    # ensure row has at least 17 columns
+    # ensure row has at least 18 columns
     if len(row_vals) < len(ORDER_HEADER):
         row_vals += [""] * (len(ORDER_HEADER) - len(row_vals))
 
@@ -597,6 +599,8 @@ def update_order_status(
         ws_orders.update_cell(row, 12, payload.scheduled_time)
     if payload.cash_amount is not None:
         ws_orders.update_cell(row, 14, payload.cash_amount)
+    if payload.comm_log is not None:
+        ws_orders.update_cell(row, 18, payload.comm_log)
 
     # add or remove from payout depending on status change
     if payload.new_status == "Livré" and row_vals[9] != "Livré":

--- a/backend/app/static/index.html
+++ b/backend/app/static/index.html
@@ -412,6 +412,9 @@
       </div>`;
 
     orders.forEach(o=>{
+      if(o.commLog){
+        try{ saveCommLog(o.orderName, JSON.parse(o.commLog)); }catch(e){};
+      }
       const tc = getPrimaryTag(o.tags);
       const isExchange = tc==='ch' || (o.tags||'').toLowerCase().includes('ch');
       const fee = isExchange ? 10 : 20;
@@ -574,6 +577,8 @@
     const log=getCommLog(order);log.calls=log.calls||[];
     log.calls.push(new Date().toLocaleString());
     saveCommLog(order,log);
+    apiPut(`/order/status?driver=${driver_id}`,
+           {order_name: order, comm_log: JSON.stringify(log)}).catch(()=>{});
     displayCommunicationLog(order);
     return true;
   }
@@ -582,6 +587,8 @@
     log.whats  = log.whats || [];
     log.whats.push(new Date().toLocaleString());
     saveCommLog(order, log);
+    apiPut(`/order/status?driver=${driver_id}`,
+           {order_name: order, comm_log: JSON.stringify(log)}).catch(()=>{});
     displayCommunicationLog(order);
     return true;          // let the <a> continue to WhatsApp
   }


### PR DESCRIPTION
## Summary
- track call/message history in Google Sheets via new `Comm Log` column
- send updates from frontend when logging WhatsApp/call actions
- load saved communication log when displaying orders

## Testing
- `python -m py_compile backend/app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e595f5044832182567fa63888e776